### PR TITLE
Update pom.xml to fix hadoop.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <clover.license>${user.home}/clover.license</clover.license>
-    <hadoop.version>2.7.1-SNAPSHOT</hadoop.version>
+    <hadoop.version>${hadoop.version}</hadoop.version>
     <jetty.version>6.1.26</jetty.version>
     <pig.version>0.13.0</pig.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>


### PR DESCRIPTION
Setting the value as a variable `<hadoop.version>${hadoop.version}</hadoop.version>` and the required hadoop.version can be set  while running the mvn command

Resolves #3 
